### PR TITLE
Add growth chemicals. Change genitalcode.

### DIFF
--- a/modular_R505/code/modules/growthchems.dm
+++ b/modular_R505/code/modules/growthchems.dm
@@ -1,0 +1,93 @@
+//These chems are currently not possible to create, merely skeletons for now.
+
+//Titchem
+/datum/reagent/drug/succubus_milk
+	name = "Succubus Milk"
+	description = "A drug, well known amongst certain circles, rumored to increase the size of one's bust."
+	taste_description = "silky smooth, with a stange and offputting aftertaste"
+	trippy = FALSE
+	overdose_threshold = 30
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/drug/succubus_milk/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	var/obj/item/organ/genital/breasts/breast
+	var/mob/living/carbon/human/H = M
+	for(var/X in H.internal_organs)
+		if(istype(X, /obj/item/organ/genital/breasts))
+			breast = X
+	if(!breast)
+		breast.uses_skintones = TRUE
+		breast.Initialize()
+		breast.Insert(H)
+	to_chat(H, "You feel a tingling in your chest...")
+	breast.change_breast_size(0.04) //1 cup size per 5u
+	..()
+	return
+
+/datum/reagent/drug/succubus_milk/overdose_process(mob/living/M, delta_time, times_fired)
+	var/obj/item/organ/genital/breasts/breast
+	var/mob/living/carbon/human/H = M
+	for(var/X in H.internal_organs)
+		if(istype(X, /obj/item/organ/genital/breasts))
+			breast = X
+	if(!breast)
+		breast.New()
+		breast.Initialize()
+		breast.uses_skintones = TRUE
+		breast.Insert(H)
+	var/obj/item/organ/genital/penis/dick
+	to_chat(H, "<span class='userdanger'>You feel your chest burn and your groin shrivel...</span>")
+	for(var/X in H.internal_organs)
+		if(istype(X, /obj/item/organ/genital/penis))
+			dick = X
+	breast.change_breast_size(0.04 * REM * delta_time) //Grow yo titties
+	if(dick)
+		dick.change_penis_length(-0.04 * REM * delta_time) //Shrink yo dicc, if you have one.
+	..()
+	return
+
+
+//Dickchem
+/datum/reagent/drug/incubus_draft
+	name = "Incubus draft"
+	description = "A drug, well known amongst certain circles, rumored to increase the size of one's member."
+	taste_description = "vile and repulsive"
+	trippy = FALSE
+	overdose_threshold = 30
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/drug/incubus_draft/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	var/obj/item/organ/genital/penis/dick
+	var/mob/living/carbon/human/H = M
+	for(var/X in H.internal_organs)
+		if(istype(X, /obj/item/organ/genital/penis))
+			dick = X
+	if(!dick)
+		dick.Initialize()
+		dick.uses_skintones = TRUE
+		dick.Insert(H)
+	to_chat(H, "You feel a tingling in your groin...")
+	dick.change_penis_length(0.04) //Increases by 1 inch per 5u.
+	..()
+	return
+
+/datum/reagent/drug/incubus_draft/overdose_process(mob/living/M, delta_time, times_fired)
+	var/obj/item/organ/genital/breasts/breast
+	var/mob/living/carbon/human/H = M
+	for(var/X in H.internal_organs)
+		if(istype(X, /obj/item/organ/genital/breasts))
+			breast = X
+	var/obj/item/organ/genital/penis/dick
+	to_chat(H, "<span class='userdanger'> You feel your groin burn and your chest flatten...</span>")
+	for(var/X in H.internal_organs)
+		if(istype(X, /obj/item/organ/genital/penis))
+			dick = X
+	if(!dick)
+		dick.Initialize()
+		dick.uses_skintones = TRUE
+		dick.Insert(H)
+	if(breast)
+		breast.change_breast_size(-0.04 * REM * delta_time) //Shrink yo titties, if you have one
+	dick.change_penis_length(0.04 * REM * delta_time) //Grow yo dicc
+	..()
+	return

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -20,6 +20,10 @@
 /obj/item/organ/genital/proc/get_sprite_size_string()
 	return 0
 
+//This is an internal function for both get_sprite_size_string() and update_genital_icon_state()
+/obj/item/organ/genital/proc/affix_size()
+	return 0
+
 //This translates the float size into a sprite string
 /obj/item/organ/genital/proc/update_sprite_suffix()
 	sprite_suffix = "[get_sprite_size_string()]"
@@ -85,9 +89,10 @@
 				returned_string += " It's fully erect."
 	return returned_string
 
-/obj/item/organ/genital/penis/update_genital_icon_state()
-	var/size_affix
+//Translates the float of size into something to be used by icon updates and sprite size strings.
+/obj/item/organ/genital/penis/affix_size()
 	var/measured_size = round(genital_size)
+	var/size_affix
 	if(measured_size < 1)
 		measured_size = 1
 	switch(measured_size)
@@ -102,6 +107,10 @@
 		else
 			size_affix = 5
 	size_affix = clamp(size_affix, 1, GLOB.penis_sprite_sizes[genital_type])
+	return size_affix
+
+/obj/item/organ/genital/penis/update_genital_icon_state()
+	var/size_affix = affix_size()
 	var/passed_string = "penis_[genital_type]_[size_affix]"
 	icon_state = passed_string
 
@@ -109,27 +118,23 @@
 	if(aroused != AROUSAL_FULL && sheath != SHEATH_NONE) //Sheath time!
 		return "[lowertext(sheath)]_[aroused == AROUSAL_PARTIAL ? 1 : 0]"
 
-	var/size_affix
-	var/measured_size = round(genital_size)
+	var/size_affix = affix_size()
 	var/is_erect = 0
+
 	if(aroused == AROUSAL_FULL)
 		is_erect = 1
-	if(measured_size < 1)
-		measured_size = 1
-	switch(measured_size)
-		if(1 to 7)
-			size_affix = 1
-		if(8 to 15)
-			size_affix = 2
-		if(16 to 24)
-			size_affix = 3
-		if(25 to 38)
-			size_affix = 4
-		else
-			size_affix = 5
-	size_affix = clamp(size_affix, 1, GLOB.penis_sprite_sizes[genital_type])
+
 	var/passed_string = "[genital_type]_[size_affix]_[is_erect]"
 	return passed_string
+
+//Increases the length of the penis, and the girth in turn. **Note: Cyanosis wants to rework girth, so that part may become defunct**
+/obj/item/organ/genital/penis/proc/change_penis_length(amount as num)
+	var/length = genital_size
+	var/girth_length_ratio = girth/length
+	genital_size += amount
+	girth = length*girth_length_ratio
+	update_genital_icon_state()
+	return
 
 /obj/item/organ/genital/penis/build_from_dna(datum/dna/DNA, associated_key)
 	..()
@@ -219,6 +224,12 @@
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_BREASTS
 	var/lactates = FALSE
+
+//Simply increases the size of booba
+/obj/item/organ/genital/breasts/proc/change_breast_size(amount as num)
+	genital_size += amount
+	update_genital_icon_state()
+	return
 
 /obj/item/organ/genital/breasts/get_description_string(datum/sprite_accessory/genital/gas)
 	var/returned_string = "You see a [lowertext(genital_name)] of breasts."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3570,6 +3570,7 @@
 #include "modular_R505\code\mob\dead\new_player\sprite_accessories\frills.dm"
 #include "modular_R505\code\mob\dead\new_player\sprite_accessories\synthliz.dm"
 #include "modular_R505\code\mob\dead\new_player\sprite_accessories\tails.dm"
+#include "modular_R505\code\modules\growthchems.dm"
 #include "modular_skyrat\master_files\code\_globalvars\configuration.dm"
 #include "modular_skyrat\master_files\code\_globalvars\maint_loot_common.dm"
 #include "modular_skyrat\master_files\code\_globalvars\maint_loot_oddity.dm"


### PR DESCRIPTION
  - Added growthchems.dm and the procs involved to do so.
  - Modified genitals.dm to enhance legibility, hopefully.
  - Modified genitals.dm to add procs to change genital size.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

As described above, adds the skeleton of growthchems into the game for more rigorous testing and later to be added as a recipe. As of this moment, to my knowledge, it grows the organ and updates the related genital's sprite. Overdosing on a chem reduces the size of the opposite organ, if it exists. Further drawbacks may be added later.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Helps with testing of genital chem code, which I was asked to make, and allows for funny adminbus as of this moment where people are suddenly injected full of "You grow now" juice. Also allows for other programmers to help in the process if they want to, since to be fair I'm still fairly new to BYOND as a language.

## Changelog

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

:cl: leroy23
add: Succubus Milk - a chemical that increases tit size. On overdose it increases tit size at the penalty of dick size.
add: Incubus Draft - a chemical that increases dick size. On overdose it increases dick size at the penalty of tit size.
del: random repeated code in the procs for penis sprites
add: proc that does the same thing and enhances the legibility of penis sprite code because it was way too lengthy for its own good.
:cl:
