### PR TITLE
Disables the autocall

### DIFF
--- a/config/skyrat/skyrat_config.txt
+++ b/config/skyrat/skyrat_config.txt
@@ -40,7 +40,7 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 ## autovote maximum votes until automatic transfer call. (default 4)
 ## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
 ## Set to -1 to disable the maximum votes cap.
-VOTE_AUTOTRANSFER_MAXIMUM 4
+VOTE_AUTOTRANSFER_MAXIMUM -1
 
 ## Policy for what people remember after dying and being brought back to life
 BLACKOUTPOLICY You remember nothing after you've blacked out and you do not remember who or what events killed you, however, you can have faint recollection of what led up to it.


### PR DESCRIPTION

## About The Pull Request

Disables the automatic shuttle call that happens roughly 30 minutes after the fourth shuttle vote

## Why It's Good For The Game

WIth low pop this autocall mostly gets in the way and has done nothing but cause issues here as far as I can tell.

## Changelog
:cl:
del: Disabled automatic shuttle call
/:cl:
