### PR TITLE
Removes safeties from tribal bows and fixes wooden arrows

### DIFF
--- a/modular_skyrat/modules/tribal_extended/code/ammo/caseless/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/caseless/arrow.dm
@@ -4,6 +4,7 @@
 	icon = 'modular_skyrat/modules/tribal_extended/icons/ammo.dmi'
 	icon_state = "arrow"
 	inhand_icon_state = "arrow"
+	projectile_type = /obj/projectile/bullet/reusable/arrow/wood
 
 /obj/item/ammo_casing/caseless/arrow/ash
 	name = "ashen arrow"

--- a/modular_skyrat/modules/tribal_extended/code/weapons/bow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/weapons/bow.dm
@@ -15,6 +15,7 @@
 	casing_ejector = FALSE
 	internal_magazine = TRUE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL //so ashwalkers can use it
+	has_gun_safety = FALSE
 
 /obj/item/gun/ballistic/tribalbow/shoot_with_empty_chamber()
 	return


### PR DESCRIPTION

## About The Pull Request

Removes safeties from the tribal bows and makes wooden arrows drop as wooden arrows instead of steel-tipped arrows.

## Why It's Good For The Game

It makes no sense for these bows to have safeties, and arrows dropping as a different variety of arrow is a bug. 

## Changelog
:cl:
del: safeties removed from tribal bows
fix: wooden arrows no longer drop as steel-tipped arrows
/:cl:


