### PR TITLE
Scan Geysers For Credit + Open W/ Regular Plunger

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -8,7 +8,8 @@
 						  /mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow = 50, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10, \
 						  /mob/living/simple_animal/hostile/asteroid/lobstrosity = 15)
 	flora_spawn_list = list(/obj/structure/flora/tree/pine = 2, /obj/structure/flora/rock/icy = 2, /obj/structure/flora/rock/pile/icy = 2, /obj/structure/flora/grass/both = 6, /obj/structure/flora/ash/chilly = 2)
-	feature_spawn_list = list(/obj/structure/geyser/random = 1)
+	///Note that this spawn list is also in the lavaland generator
+	feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
 
 /datum/map_generator/cave_generator/icemoon/surface
 	flora_spawn_chance = 4

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -8,7 +8,8 @@
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random = 30, /obj/structure/spawner/lavaland/legion = 3, \
 		SPAWN_MEGAFAUNA = 4, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10)
 	flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
-	feature_spawn_list = list(/obj/structure/geyser/random = 1)
+	///Note that this spawn list is also in the icemoon generator
+	feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
 
 	initial_closed_chance = 45
 	smoothing_iterations = 50

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -1,23 +1,40 @@
 //If you look at the "geyser_soup" overlay icon_state, you'll see that the first frame has 25 ticks.
 //That's because the first 18~ ticks are completely skipped for some ungodly weird fucking byond reason
 
+///A lavaland geyser that spawns chems and can be mining scanned for points. Made to work with the plumbing pump to extract that sweet rare nectar
 /obj/structure/geyser
 	name = "geyser"
 	icon = 'icons/obj/lavaland/terrain.dmi'
 	icon_state = "geyser"
 	anchored = TRUE
 
-	var/erupting_state = null //set to null to get it greyscaled from "[icon_state]_soup". Not very usable with the whole random thing, but more types can be added if you change the spawn prob
-	var/activated = FALSE //whether we are active and generating chems
+	///set to null to get it greyscaled from "[icon_state]_soup". Not very usable with the whole random thing, but more types can be added if you change the spawn prob
+	var/erupting_state = null
+	//whether we are active and generating chems
+	var/activated = FALSE
+	///what chem do we produce?
 	var/reagent_id = /datum/reagent/fuel/oil
-	var/potency = 2 //how much reagents we add every process (2 seconds)
+	///how much reagents we add every process (2 seconds)
+	var/potency = 2
+	///maximum volume
 	var/max_volume = 500
+	///how much we start with after getting activated
 	var/start_volume = 50
+
+	///Have we been discovered with a mining scanner?
+	var/discovered = FALSE
+	///How many points we grant to whoever discovers us
+	var/point_value = 100
+	///what's our real name that will show upon discovery? null to do nothing
+	var/true_name
+	///the message given when you discover this geyser.
+	var/discovery_message = null
 
 /obj/structure/geyser/Initialize(mapload) //if xenobio wants to bother, nethermobs are around geysers.
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_NETHER, CELL_VIRUS_TABLE_GENERIC, 1, 5)
 
+///Start producing chems, should be called just once
 /obj/structure/geyser/proc/start_chemming()
 	activated = TRUE
 	create_reagents(max_volume, DRAINABLE)
@@ -46,14 +63,60 @@
 	if(do_after(user, 50 * P.plunge_mod, target = src) && !activated)
 		start_chemming()
 
+/obj/structure/geyser/attackby(obj/item/item, mob/user, params)
+	if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
+		return
+
+	if(discovered)
+		to_chat(user, "<span class='warning'>This geyser has already been discovered!</span>")
+		return
+
+	to_chat(user, "<span class='notice'>You discovered the geyser and mark it on the GPS system!</span>")
+	if(discovery_message)
+		to_chat(user, discovery_message)
+
+	discovered = TRUE
+	if(true_name)
+		name = true_name
+
+	AddComponent(/datum/component/gps, true_name) //put it on the gps so miners can mark it and chemists can profit off of it
+
+	if(isliving(user))
+		var/mob/living/living = user
+
+		var/obj/item/card/id/card = living.get_idcard()
+		if(card)
+			to_chat(user, "<span class='notice'>[point_value] mining points have been paid out!</span>")
+			card.mining_points += point_value
+
+/obj/structure/geyser/wittel
+	reagent_id = /datum/reagent/wittel
+	point_value = 250
+	true_name = "wittel geyser"
+	discovery_message = "It's a rare wittel geyser! This could be very powerful in the right hands... "
+
+/obj/structure/geyser/plasma_oxide
+	reagent_id = /datum/reagent/plasma_oxide
+	true_name = "plasma-oxide geyser"
+
+/obj/structure/geyser/protozine
+	reagent_id = /datum/reagent/medicine/omnizine/protozine
+	true_name = "protozine geyser"
+
+/obj/structure/geyser/hollowwater
+	reagent_id = /datum/reagent/water/hollowwater
+	true_name = "hollow water geyser"
+
 /obj/structure/geyser/random
-	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10,/datum/reagent/plasma_oxide = 8, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	point_value = 500
+	true_name = "strange geyser"
+	discovery_message = "It's a strange geyser! How does any of this even work?" //It doesn't
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()
-	reagent_id = pickweight(options)
+	reagent_id = get_random_reagent_id()
 
+///A wearable tool that lets you empty plumbing machinery and some other stuff
 /obj/item/plunger
 	name = "plunger"
 	desc = "It's a plunger for plunging."
@@ -67,7 +130,7 @@
 	///time*plunge_mod = total time we take to plunge an object
 	var/plunge_mod = 1
 	///whether we do heavy duty stuff like geysers
-	var/reinforced = FALSE
+	var/reinforced = TRUE
 	///alt sprite for the toggleable layer change mode
 	var/layer_mode_sprite = "plunger_layer"
 	///Wheter we're in layer mode
@@ -118,13 +181,14 @@
 	if(new_layer)
 		target_layer = layers[new_layer]
 
+///A faster reinforced plunger
 /obj/item/plunger/reinforced
 	name = "reinforced plunger"
 	desc = "It's an M. 7 Reinforced Plunger© for heavy duty plunging."
 	icon_state = "reinforced_plunger"
 	worn_icon_state = "reinforced_plunger"
 	reinforced = TRUE
-	plunge_mod = 0.8
+	plunge_mod = 0.5
 	layer_mode_sprite = "reinforced_plunger_layer"
 
 	custom_premium_price = PAYCHECK_MEDIUM * 8

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -65,8 +65,7 @@
 						/obj/item/reagent_containers/pill/morphine = 4,
 						/obj/item/reagent_containers/pill/multiver = 6)
 	premium = list(/obj/item/reagent_containers/medigel/synthflesh = 2,
-					/obj/item/storage/pill_bottle/psicodine = 2,
-					/obj/item/plunger/reinforced = 2)
+					/obj/item/storage/pill_bottle/psicodine = 2)
 	default_price = 50
 	extra_price = 100
 	payment_department = ACCOUNT_MED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/58859

## Why It's Good For The Game
As per the original PR:
 "Geysers are now not locked behind a massive money paywall, which was designed with paychecks in mind.

Miners can now assist chemists by marking geysers and get incentivized to do so, making a chemists decision to work with geysers a lot more reliable since you already know what you're gonna get in most cases."
## Changelog
:cl:
balance: Geysers can be opened with regular plungers and can be scanned and marked with a mining scanner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
