### PR TITLE
Introducing Infested CMEs and Heliophage Spores

### DIFF
--- a/modular_R505/code/datums/events/cme/infested_cme.dm
+++ b/modular_R505/code/datums/events/cme/infested_cme.dm
@@ -1,0 +1,23 @@
+/datum/round_event_control/cme/infested
+	name = "Infested Coronal Mass Ejection"
+	typepath = /datum/round_event/cme/infested
+	weight = 5
+	max_occurrences = 1
+	earliest_start = 25 MINUTES
+
+/datum/round_event/cme/infested
+	cme_intensity = "minimal" //very minor hack because we compile before Ratcode.
+
+/datum/round_event/cme/infested/announce()
+	. = ..()
+	spawn(rand(2,4)*100)
+		priority_announce("WARNING: Long-range monitoring satellites have detected unknown lifesigns in the approaching solar storm. \
+		Caution is advised when approaching magnetic field event sites.", "Solar Event Update", sound('modular_skyrat/modules/cme/sound/cme_warning.ogg'))
+
+
+
+/datum/round_event/cme/infested/spawn_cme(turf/spawnpoint, intensity)
+	. = ..()
+	//spawn heliophages
+	for(var/i = 0 to rand(1,6))
+		new /mob/living/simple_animal/hostile/heliophage/spore(spawnpoint)

--- a/modular_R505/code/mobs/heliophage.dm
+++ b/modular_R505/code/mobs/heliophage.dm
@@ -36,8 +36,8 @@
 
 /mob/living/simple_animal/hostile/heliophage/Destroy()
 	var/turf/open/location = get_turf(loc)
-	//Add smol trit fire on death
-	location.atmos_spawn_air("o2=5;tritium=5;TEMP=1000")
+	//Add smol plas fire on death
+	location.atmos_spawn_air("o2=5;plasma=5;TEMP=1000")
 	. = ..()
 
 //Your most basic form of Heliophage - little floaty balls of fiery energy. Weak but fast-moving.

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -41,8 +41,9 @@ Armageddon is truly going to fuck the station, use it sparingly.
 /datum/round_event_control/cme/minimal
 	name = "Coronal Mass Ejection: Minimal"
 	typepath = /datum/round_event/cme/minimal
-	weight = 0
-	max_occurrences = 0
+	weight = 5 //R505 edit - rare natural spawn
+	max_occurrences = 1
+	earliest_start = 25 MINUTES
 
 /datum/round_event/cme/minimal
 	cme_intensity = CME_MINIMAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3875,6 +3875,7 @@
 #include "modular_R505\code\datums\components\cleanable.dm"
 #include "modular_R505\code\datums\components\crafting\duraskirt.dm"
 #include "modular_R505\code\datums\events\roundstart_events.dm"
+#include "modular_R505\code\datums\events\cme\infested_cme.dm"
 #include "modular_R505\code\datums\events\dust_storm\dust_obj.dm"
 #include "modular_R505\code\datums\events\dust_storm\dust_storm.dm"
 #include "modular_R505\code\datums\mood_events\arousal.dm"


### PR DESCRIPTION
## About The Pull Request
The famed adminbus critters can now spawn naturally! Borne aloft from their natural habitat by a coronal mass ejection, the radiant, plasma-eating Heliophages can now turn up on the station to cause trouble for the crew.