### PR TITLE
Increases metabolism rate on succubus milk

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/chemistry_for_ERP.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/chemistry_for_ERP.dm
@@ -208,7 +208,7 @@
 	color = "#E60584" // rgb: 96, 0, 255
 	taste_description = "a milky ice cream like flavour."
 	overdose_threshold = 17
-	metabolization_rate = 0.25
+	metabolization_rate = 0.5
 	var/message_spam = FALSE
 
 /datum/reagent/breast_enlarger/on_mob_metabolize(mob/living/M)
@@ -272,7 +272,7 @@
 	if(!(M.client?.prefs.skyrat_toggles & FORCED_FEM))
 		var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
 		if(L)
-			L.applyOrganDamage(0.25)
+			L.applyOrganDamage(0)
 		return ..()
 
 	if(M.gender == MALE)


### PR DESCRIPTION
Also gets rid of liver damage on OD



## About The Pull Request

Raises metabolism rate on Succubus milk from 0.25 to 0.5 and removes liver damage on OD

## Why It's Good For The Game

makes succubus milk work at a pace faster than the lethargic snail's pace it was before.

## Changelog
:cl:
del: Liver damage on OD
Add: Faster metabolizing rate
/:cl:


