### PR TITLE
DTR goes in suit storage, not suit slot

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/guns.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/guns.dm
@@ -482,7 +482,7 @@
 	alt_icons = TRUE
 	alt_icon_state = "ostwind_worn"
 	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT | ITEM_SLOT_OCLOTHING
+	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT | ITEM_SLOT_SUITSTORE
 	mag_type = /obj/item/ammo_box/magazine/multi_sprite/ostwind
 	spread = 10
 	fire_delay = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents DTR-6 from going into the suit slot, and makes it capable of going in the suit storage slot.

## Why It's Good For The Game

Fixes nonsensical behavior

## Changelog
:cl:
fix: DTR-6 now appropriately fits in the suit storage slot rather than the suit slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
