### PR TITLE
Returns the M45A5 Elite to it's former glory and true owner.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/modules/jobs/job_types/blueshield.dm
@@ -69,12 +69,13 @@
 
 
 /obj/item/storage/box/gunset/blueshield
-	name = "CFA 'Lynx' Gunset"
+	name = "M45A5 Gunset" //R505 Edit
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/box/gunset/blueshield/PopulateContents()
 	. = ..()
-	new /obj/item/gun/ballistic/automatic/cfa_lynx/no_mag(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx(src)
-	new /obj/item/ammo_box/magazine/multi_sprite/cfa_lynx(src)
+	new /obj/item/gun/ballistic/automatic/pistol/m45a5/nomag(src) //R505 Edit Start
+	new /obj/item/ammo_box/magazine/m45a5(src)
+	new /obj/item/ammo_box/magazine/m45a5(src)
+	new /obj/item/ammo_box/magazine/m45a5(src)
+	new /obj/item/ammo_box/magazine/m45a5(src) //R505 Edit End

--- a/modular_skyrat/modules/nanotrasen_rep/code/m45a5.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/m45a5.dm
@@ -8,7 +8,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/m45a5
 	can_suppress = FALSE
-	fire_delay = 4.25 //Originally 1.75 which was unintentionally extremely fast.
+	fire_delay = 1.75 //R505 Edit - welcome to the glory days
 	fire_sound_volume = 60
 	spread = 2
 	force = 8 //There's heavier guns that dealt less damage on melee than this so we're reducing it from the original 12


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the M45A5 Elite fire delay to the original 1.75, and gives the gun back to the blueshield. This does not remove it from the NT reps possession.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We don't like this new autorifle gun, or the slower M45A5 Elite.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: M45A5 fire delay restored to former glory. (1.75)
fix: Changed the CFA Lynx back to a M45A5 Elite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
