### PR TITLE
Atmos Scrubbers Scrub Pollutants

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -252,6 +252,7 @@
 					"long_name" = sanitize(long_name),
 					"power" = info["power"],
 					"scrubbing" = info["scrubbing"],
+					"pollutionscrubbing" = info["pollutionscrubbing"], //R505 Edit
 					"widenet" = info["widenet"],
 					"filter_types" = info["filter_types"]
 				))
@@ -311,7 +312,7 @@
 			if(usr.has_unlimited_silicon_privilege && !wires.is_cut(WIRE_IDSCAN))
 				locked = !locked
 				. = TRUE
-		if("power", "toggle_filter", "widenet", "scrubbing", "direction")
+		if("power", "toggle_filter", "widenet", "scrubbing", "direction", "pollutionscrubbing") //R505 Edit - added: , "pollutionscrubbing"
 			send_signal(device_id, list("[action]" = params["val"]), usr)
 			. = TRUE
 		if("excheck")

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -141,6 +141,14 @@
 			scrub(tile)
 	return TRUE
 
+//R505 Edit
+/obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrubPollution(var/scrub_amount)
+	if(isopenturf(get_turf(src)))
+		var/turf/open/open_turf = get_turf(src)
+		if(open_turf.pollution)
+			open_turf.pollution.ScrubAmount(scrub_amount)
+			use_power(100)
+
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrub(turf/tile)
 	if(!istype(tile))
 		return FALSE
@@ -153,6 +161,7 @@
 
 	if(scrubbing == SCRUBBING)
 		if(length(env_gases & filter_types))
+			scrubPollution(2) //R505 Edit
 			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
 
 			//Take a gas sample
@@ -182,7 +191,14 @@
 			update_parents()
 
 	else //Just siphoning all air
-
+		scrubPollution(8) //R505 Edit
+		//R505 Edit
+		//if(isopenturf(get_turf(src)))
+			//var/turf/open/open_turf = get_turf(src)
+			//if(open_turf.pollution)
+				//open_turf.pollution.ScrubAmount(8)
+				//use_power(100)
+			//R505 Edit - End
 		var/transfer_moles = environment.total_moles() * (volume_rate / environment.volume)
 
 		var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -1,6 +1,7 @@
 #define SIPHONING 0
 #define SCRUBBING 1
-
+#define AGGFILTER 0
+#define REGFILTER 1
 /obj/machinery/atmospherics/components/unary/vent_scrubber
 	icon_state = "scrub_map-3"
 
@@ -16,6 +17,7 @@
 	shift_underlay_only = FALSE
 
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
+	var/pollutionscrubbing = REGFILTER //R505 Edit. 0 = active filter, 1 = passive
 
 	var/filter_types = list(/datum/gas/carbon_dioxide)
 	var/volume_rate = 200
@@ -97,7 +99,8 @@
 		"scrubbing" = scrubbing,
 		"widenet" = widenet,
 		"filter_types" = f_types,
-		"sigtype" = "status"
+		"sigtype" = "status",
+		"pollutionscrubbing" = pollutionscrubbing //R505 Edit
 	))
 
 	var/area/scrub_area = get_area(src)
@@ -148,7 +151,8 @@
 		if(open_turf.pollution)
 			open_turf.pollution.ScrubAmount(scrub_amount)
 			use_power(100)
-
+			message_admins("Pollution scrubbing at: [scrub_amount]")
+//R505 Edit - End
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrub(turf/tile)
 	if(!istype(tile))
 		return FALSE
@@ -161,7 +165,10 @@
 
 	if(scrubbing == SCRUBBING)
 		if(length(env_gases & filter_types))
-			scrubPollution(2) //R505 Edit
+			if(pollutionscrubbing)
+				scrubPollution(2) //R505 Edit
+			else
+				scrubPollution(8) //R505 Edit
 			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
 
 			//Take a gas sample
@@ -247,6 +254,13 @@
 		scrubbing = !scrubbing
 	if(scrubbing != old_scrubbing)
 		investigate_log(" was toggled to [scrubbing ? "scrubbing" : "siphon"] mode by [key_name(signal_sender)]",INVESTIGATE_ATMOS)
+
+//R505 Edit
+	if("pollutionscrubbing" in signal.data)
+		pollutionscrubbing = text2num(signal.data["pollutionscrubbing"])
+	if("toggle_pollutionscrubbing" in signal.data)
+		pollutionscrubbing = !pollutionscrubbing
+//R505 Edit - End
 
 	if("toggle_filter" in signal.data)
 		filter_types ^= gas_id2path(signal.data["toggle_filter"])
@@ -353,3 +367,5 @@
 
 #undef SIPHONING
 #undef SCRUBBING
+#undef AGGFILTER
+#undef REGFILTER

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -145,13 +145,13 @@
 	return TRUE
 
 //R505 Edit
-/obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrubPollution(var/scrub_amount)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrubPollution(var/scrub_amount, var/reqPower)
 	if(isopenturf(get_turf(src)))
 		var/turf/open/open_turf = get_turf(src)
 		if(open_turf.pollution)
 			open_turf.pollution.ScrubAmount(scrub_amount)
-			use_power(100)
-			message_admins("Pollution scrubbing at: [scrub_amount]")
+			if(reqPower)
+				use_power((50 * scrub_amount)-100)
 //R505 Edit - End
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrub(turf/tile)
 	if(!istype(tile))
@@ -166,9 +166,9 @@
 	if(scrubbing == SCRUBBING)
 		if(length(env_gases & filter_types))
 			if(pollutionscrubbing)
-				scrubPollution(2) //R505 Edit
+				scrubPollution(2, TRUE) //R505 Edit
 			else
-				scrubPollution(8) //R505 Edit
+				scrubPollution(8, TRUE) //R505 Edit
 			var/transfer_moles = min(1, volume_rate / environment.volume) * environment.total_moles()
 
 			//Take a gas sample
@@ -198,14 +198,7 @@
 			update_parents()
 
 	else //Just siphoning all air
-		scrubPollution(8) //R505 Edit
-		//R505 Edit
-		//if(isopenturf(get_turf(src)))
-			//var/turf/open/open_turf = get_turf(src)
-			//if(open_turf.pollution)
-				//open_turf.pollution.ScrubAmount(8)
-				//use_power(100)
-			//R505 Edit - End
+		scrubPollution(12, FALSE) //R505 Edit
 		var/transfer_moles = environment.total_moles() * (volume_rate / environment.volume)
 
 		var/datum/gas_mixture/removed = tile.remove_air(transfer_moles)

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -157,9 +157,9 @@ export const Scrubber = (props, context) => {
               val: Number(!widenet),
             })} />
           <Button
-            icon={pollutionscrubbing ? 'expand' : 'compress'}
-            selected={pollutionscrubbing}
-            content={pollutionscrubbing ? 'Active Filtering' : 'Passive Filtering'}
+            icon={pollutionscrubbing ? 'compress' : 'expand'}
+            selected={!pollutionscrubbing}
+            content={pollutionscrubbing ? 'Passive Filtering' : 'Active Filtering'}
             onClick={() => act('pollutionscrubbing', {
               id_tag,
               val: Number(!pollutionscrubbing),

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -122,6 +122,7 @@ export const Scrubber = (props, context) => {
     id_tag,
     widenet,
     filter_types,
+    pollutionscrubbing, //R505 Edit
   } = scrubber;
   return (
     <Section
@@ -155,6 +156,15 @@ export const Scrubber = (props, context) => {
               id_tag,
               val: Number(!widenet),
             })} />
+          <Button
+            icon={pollutionscrubbing ? 'expand' : 'compress'}
+            selected={pollutionscrubbing}
+            content={pollutionscrubbing ? 'Active Filtering' : 'Passive Filtering'}
+            onClick={() => act('pollutionscrubbing', {
+              id_tag,
+              val: Number(!pollutionscrubbing),
+            })}/>
+
         </LabeledList.Item>
         <LabeledList.Item label="Filters">
           {scrubbing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows scrubbers to scrub pollution, including a toggle in the air alarm interface that allows them to scrub them more effectively at the cost of increased power consumption.

## Why It's Good For The Game

Keeps people from choking the station by smoking cigs

## Changelog
:cl:
add: Atmos Scrubbers Scrub Pollution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
