### PR TITLE
Brings back navy tacticool sprite.

### DIFF
--- a/modular_skyrat/modules/aesthetics/clothing/clothing.dm
+++ b/modular_skyrat/modules/aesthetics/clothing/clothing.dm
@@ -154,3 +154,8 @@
 	//worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
 	//icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
 //R505 Edit - these will become their own item.
+
+obj/item/clothing/under/syndicate/tacticool
+	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/uniform.dmi'
+	icon = 'modular_skyrat/master_files/icons/obj/clothing/uniforms.dmi'
+//R505 Edit - Forgot this was a subtype, this one can stay because the new one is better plus it has a toggle.


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I forgot that tacticool is a subtype of real syndicate, and the navy sprites only exist on the modular file, so they lost their navy option. This brings that specifically back.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Navy looks better than classic, and this has a working toggle already, so there's no reason not to give the option.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tacticool sprite toggle actually toggles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
