### PR TITLE
Nerfs Bureaucratic Error Event

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -12,6 +12,7 @@
 
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.joinable_occupations.Copy()
+	/* //R505 Edit
 	if(prob(33)) // Only allows latejoining as a single role. Add latejoin AI bluespace pods for fun later.
 		var/datum/job/overflow = pick_n_take(jobs)
 		overflow.spawn_positions = -1
@@ -22,8 +23,9 @@
 				continue
 			current.total_positions = 0
 	else // Adds/removes a random amount of job slots from all jobs.
-		for(var/datum/job/current as anything in jobs)
-			if(!current.allow_bureaucratic_error)
-				continue
-			var/ran = rand(-2,4)
-			current.total_positions = max(current.total_positions + ran, 0)
+	*/ //R505 Edit - End
+	for(var/datum/job/current as anything in jobs)
+		if(!current.allow_bureaucratic_error)
+			continue
+		var/ran = rand(-2,4)
+		current.total_positions = max(current.total_positions + ran, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes the bureaucratic error event less annoying by removing the 33% chance to close all roles to latejoin except for one.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Being able to join only as a single role is annoying as hell, and the extent of it makes fixing it without admdin intervention impractical

## Changelog
:cl:
balance: bureaucratic error event nerfed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
